### PR TITLE
Use Bun 1.3.12 Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.9 AS base
+FROM oven/bun:1.3.12 AS base
 WORKDIR /app
 
 # Install dependencies
@@ -7,7 +7,8 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
 
 # Production image
-FROM base
+FROM oven/bun:1.3.12-distroless
+WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json bun.lock tsconfig.json drizzle.config.ts ./
 COPY src ./src

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY drizzle ./drizzle
 ENV NODE_ENV=production
 EXPOSE 3000
 
-CMD ["bun", "src/entrypoints/main.ts", "http"]
+CMD ["src/entrypoints/main.ts", "http"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM oven/bun:1
+FROM oven/bun:1.3.12
 WORKDIR /app
 
 COPY package.json bun.lock ./


### PR DESCRIPTION
## Summary
- pin production and development Docker images to Bun 1.3.12
- use the Bun 1.3.12 distroless image for the production runtime
- adjust the production CMD for the distroless image entrypoint

## Verification
- docker build -t location-tracker:issue-12 .
- docker build -f Dockerfile.dev -t location-tracker-dev:issue-12 .
- just docker-run confirmed the HTTP server starts on http://localhost:3000

Closes #12