### PR TITLE
Add Dockerized Semgrep scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
           bun-version: 1.3.9
       - run: bun install --frozen-lockfile
       - run: just fmt-check
+      - run: just semgrep
       - run: just check

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,20 @@ FROM base AS deps
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
 
+FROM base AS runtime-dir
+RUN mkdir -p /home/bun/app && chown -R bun:bun /home/bun/app
+
 # Production image
 FROM oven/bun:1.3.12-distroless
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-COPY package.json bun.lock tsconfig.json drizzle.config.ts ./
-COPY src ./src
-COPY drizzle ./drizzle
+COPY --from=runtime-dir --chown=1000:1000 /home/bun/app /home/bun/app
+WORKDIR /home/bun/app
+COPY --from=deps --chown=1000:1000 /app/node_modules ./node_modules
+COPY --chown=1000:1000 package.json bun.lock tsconfig.json drizzle.config.ts ./
+COPY --chown=1000:1000 src ./src
+COPY --chown=1000:1000 drizzle ./drizzle
 
 ENV NODE_ENV=production
 EXPOSE 3001
 
+USER 1000:1000
 CMD ["src/entrypoints/main.ts", "http"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.12 AS base
+FROM oven/bun:1.3.13 AS base
 WORKDIR /app
 
 # Install dependencies
@@ -10,7 +10,7 @@ FROM base AS runtime-dir
 RUN mkdir -p /home/bun/app && chown -R bun:bun /home/bun/app
 
 # Production image
-FROM oven/bun:1.3.12-distroless
+FROM oven/bun:1.3.13-distroless
 COPY --from=runtime-dir --chown=1000:1000 /home/bun/app /home/bun/app
 WORKDIR /home/bun/app
 COPY --from=deps --chown=1000:1000 /app/node_modules ./node_modules

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,13 @@
 FROM oven/bun:1.3.12
-WORKDIR /app
+WORKDIR /home/bun/app
+RUN chown -R bun:bun /home/bun/app
 
-COPY package.json bun.lock ./
+COPY --chown=bun:bun package.json bun.lock ./
+USER bun
 RUN bun install
 
 # Source code is mounted as a volume at runtime for hot reloading.
-# Run with: docker run -v ./src:/app/src -v ./tsconfig.json:/app/tsconfig.json -p 3000:3000 <image>
+# Run with: docker run -v ./src:/home/bun/app/src -v ./tsconfig.json:/home/bun/app/tsconfig.json -p 3000:3000 <image>
 
 EXPOSE 3000
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.12
+FROM oven/bun:1.3.13
 WORKDIR /home/bun/app
 RUN chown -R bun:bun /home/bun/app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,8 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/app
-      - /app/node_modules
+      - .:/home/bun/app
+      - /home/bun/app/node_modules
     environment:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432

--- a/justfile
+++ b/justfile
@@ -54,7 +54,12 @@ fmt-check:
 
 # Run Semgrep in Docker against Bun source and Dockerfiles
 semgrep:
-    docker run --rm -v "$PWD/src:/src/src:ro" -v "$PWD/Dockerfile:/src/Dockerfile:ro" -v "$PWD/Dockerfile.dev:/src/Dockerfile.dev:ro" -w /src semgrep/semgrep semgrep scan --scan-unknown-extensions --error --config auto src Dockerfile Dockerfile.dev
+    docker run --rm \
+        -v "$PWD/src:/src/src:ro" \
+        -v "$PWD/Dockerfile:/src/Dockerfile:ro" \
+        -v "$PWD/Dockerfile.dev:/src/Dockerfile.dev:ro" \
+        -w /src \
+        semgrep/semgrep:1.159.0 semgrep scan --scan-unknown-extensions --error --config auto src Dockerfile Dockerfile.dev
 
 # Install dependencies
 install:

--- a/justfile
+++ b/justfile
@@ -52,6 +52,10 @@ fmt:
 fmt-check:
     bunx oxfmt --check src/
 
+# Run Semgrep in Docker against Bun source and Dockerfiles
+semgrep:
+    docker run --rm -v "$PWD/src:/src/src:ro" -v "$PWD/Dockerfile:/src/Dockerfile:ro" -v "$PWD/Dockerfile.dev:/src/Dockerfile.dev:ro" -w /src semgrep/semgrep semgrep scan --scan-unknown-extensions --error --config auto src Dockerfile Dockerfile.dev
+
 # Install dependencies
 install:
     bun install
@@ -74,7 +78,7 @@ docker-run: docker-build
 
 # Run development Docker container with hot reloading
 docker-dev: docker-build-dev
-    docker run -v ./src:/app/src -v ./drizzle:/app/drizzle -v ./tsconfig.json:/app/tsconfig.json -p 3000:3000 location-tracker-dev
+    docker run -v ./src:/home/bun/app/src -v ./drizzle:/home/bun/app/drizzle -v ./tsconfig.json:/home/bun/app/tsconfig.json -p 3000:3000 location-tracker-dev
 
 # Generate a new Drizzle migration from schema changes
 db-generate:
@@ -116,6 +120,7 @@ test-data url="http://localhost:3000":
 ci:
     bun install --frozen-lockfile
     just fmt-check
+    just semgrep
     just check
 
 # Run all checks (typecheck, lint, test)

--- a/src/infrastructure/logging/console.logger.ts
+++ b/src/infrastructure/logging/console.logger.ts
@@ -2,14 +2,14 @@ import type { Logger } from '@/domain/ports.ts';
 
 export class ConsoleLogger implements Logger {
   info(message: string, data?: unknown): void {
-    console.warn(`[INFO] ${message}`, data !== undefined ? data : '');
+    console.warn('%s', `[INFO] ${message}`, data !== undefined ? data : '');
   }
 
   warn(message: string, data?: unknown): void {
-    console.warn(`[WARN] ${message}`, data !== undefined ? data : '');
+    console.warn('%s', `[WARN] ${message}`, data !== undefined ? data : '');
   }
 
   error(message: string, data?: unknown): void {
-    console.error(`[ERROR] ${message}`, data !== undefined ? data : '');
+    console.error('%s', `[ERROR] ${message}`, data !== undefined ? data : '');
   }
 }


### PR DESCRIPTION
## Summary
- add a `just semgrep` command that runs Semgrep in Docker against `src/`, `Dockerfile`, and `Dockerfile.dev`
- run Semgrep in CI for pushes and pull requests targeting `main`
- fix Semgrep findings by running Docker images as non-root and avoiding dynamic console format strings
- pin the Semgrep container image to `semgrep/semgrep:1.159.0`

## Verification
- `just semgrep` - 0 findings, both Dockerfiles included
- `just docker-build`
- `just docker-build-dev`
- production image smoke test with `ENCRYPTION_KEY` set

Closes #9