### PR TITLE
feat: add geofencing capabilities for predefined areas

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,20 @@ services:
     networks:
       - internal
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
   http:
     build:
       context: .
@@ -31,8 +45,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-location_tracker}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      REDIS_URL: redis://redis:6379
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks:
       - internal
@@ -42,3 +59,4 @@ networks:
 
 volumes:
   pg_data:
+  redis_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,19 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   http:
     build:
       context: .
@@ -33,9 +46,13 @@ services:
       POSTGRES_DB: location_tracker
       PORT: "3000"
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      REDIS_URL: redis://redis:6379
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
 volumes:
   pg_data:
+  redis_data:

--- a/docs/geofencing.md
+++ b/docs/geofencing.md
@@ -1,0 +1,369 @@
+# Plan — Per-User Geofencing for Predefined Areas (Issue #18 / LT-18)
+
+## Context
+
+**Why:** Issue #18 asks for server-side geofencing so the system can react when a
+user enters or leaves a predefined circular area. Today the app only _persists_
+device-reported OwnTracks `transition` events (the phone computes those
+client-side); it does not compute geofence membership itself and has no notion of
+server-defined areas.
+
+**What we're building:** An `AreaRepository` that stores per-user circular
+geofences (`lat`, `lon`, `radius`), plus a geofence engine that — **inside Redis,
+not in the Bun app** — decides which of a user's areas contain each incoming
+location, diffs that against prior state, and emits **enter** / **exit** events.
+Exit events fire only after the user has been outside for a threshold cushion
+(default 60s), to avoid flapping. Traccar's geofence transition model is the
+reference: areas + enter/leave events, per account.
+
+**Hard constraints from the issue:**
+
+- Areas are circular: `lat`, `lon` (issue says "lng"; we use `lon` to match the
+  existing domain vocabulary), `radius` (meters).
+- Enter/exit **events** are emitted.
+- An **exit cushion** (~60s) before firing the exit event.
+- The membership computation happens **in Redis** — the Bun app must _not_ loop
+  over areas doing point-in-circle math.
+- Geofences are **per-user**; only a user's own areas apply to them.
+
+**Confirmed design decisions (from clarification):**
+
+1. **User key = `tid`** (already on every `LocationPayload`; areas store a
+   matching `userId`).
+2. **Area store = Redis-only** with persistence (AOF) enabled — Redis is the
+   source of truth; no SQL mirror.
+3. **Exit trigger = on next location update** past the cushion. A device that
+   goes silent right after leaving delays its exit event; documented as a known
+   limitation (a background sweeper is out of scope — see Future Work).
+4. **Event sinks = Redis Pub/Sub + DB persistence + NotificationSender**, fanned
+   out through a re-introduced `EventPublisher` port (also closes issue #6).
+
+---
+
+## Architecture Overview
+
+Everything follows the existing ports/adapters layout (`@/domain/ports.ts`
+interfaces implemented by `@/infrastructure/*` and `@/repository/*` adapters,
+wired in `@/entrypoints/http.ts`, invoked from `@/application/handlers/*`).
+
+Ingestion path stays the same:
+`POST /pub` → `server.ts` (Zod validate) → `handlePayload` → `handleLocation`.
+We add one step in `handleLocation`: after saving the location, call the
+**geofence evaluator** and publish whatever events it returns.
+
+```text
+LocationPayload (tid, lat, lon, tst)
+        │
+        ▼
+ handleLocation ──► repo.saveLocation (unchanged)
+        │
+        ▼
+ geofence.evaluate(tid, lon, lat, tst)     ← runs a Lua script IN Redis
+        │  returns GeofenceEvent[]
+        ▼
+ for each event: eventPublisher.publish(event)
+        │
+        ├─► RedisEventPublisher   (PUBLISH geofence:events)
+        ├─► DbEventPublisher      (INSERT into area_events)
+        └─► NotificationEventPublisher ──► NotificationSender
+```
+
+### Why the geofencing lives in a Redis Lua script
+
+To honor "do NOT have the Bun app handle which areas a user is in," the entire
+membership + state-diff + cushion logic runs as a **single atomic Lua script**
+(`EVALSHA`, with an `EVAL`/`SCRIPT LOAD` fallback on `NOSCRIPT`). The Bun app
+passes `(userId, lon, lat, tst, thresholdSeconds)` in and gets a list of typed
+events out. Redis does all the geometry (via GEO commands) and owns all the
+per-user state. This is atomic (no read-modify-write races across concurrent
+location updates for the same user) and keeps the app a thin relay.
+
+---
+
+## Redis Data Model (per user, keyed by `tid`)
+
+| Key | Type | Purpose | Written by |
+| --- | --- | --- | --- |
+| `geo:areas:{userId}` | GEO sorted set | Area centers (member = `areaId`, at `lon`/`lat`) | `AreaRepository` via `GEOADD` |
+| `area:meta:{userId}` | HASH | `areaId` → JSON `{ name, radius }` (radius not stored by GEO) | `AreaRepository` |
+| `area:maxradius:{userId}` | string | Largest radius among the user's areas (bounds the GEOSEARCH) | `AreaRepository` maintains on add/remove |
+| `geofence:inside:{userId}` | SET | `areaId`s the user is currently considered inside | Lua script |
+| `geofence:pending-exit:{userId}` | HASH | `areaId` → `tst` when it first went outside (cushion timer) | Lua script |
+
+Note: Redis GEO commands take **(longitude, latitude)** order — the code must pass
+`lon` before `lat`. Membership is **inclusive** (`distance <= radius`).
+
+### `AreaRepository` behavior (Redis adapter)
+
+- `addArea(area)` → `GEOADD geo:areas:{userId} lon lat areaId`, `HSET area:meta`,
+  recompute/raise `area:maxradius`.
+- `removeArea(userId, areaId)` → `ZREM` + `HDEL` meta + recompute maxradius +
+  `SREM geofence:inside` + `HDEL geofence:pending-exit` (clean up stale state).
+- `listAreas(userId)` / `getArea(userId, areaId)` → read GEO pos + meta.
+- `healthCheck()` → `PING` (mirrors `LocationRepository.healthCheck`).
+
+### Geofence evaluation Lua algorithm (runs in Redis)
+
+Input: `userId, lon, lat, tst, thresholdSeconds`. Steps:
+
+1. If `geo:areas:{userId}` is empty → return `[]`.
+2. `maxR = GET area:maxradius:{userId}`.
+3. `candidates = GEOSEARCH geo:areas:{userId} FROMLONLAT lon lat BYRADIUS maxR m WITHDIST`
+   → list of `(areaId, distanceMeters)`. (Anything outside `maxR` cannot be
+   inside any area, since every radius ≤ maxR.)
+4. `nowInside = { areaId : distance <= radius(areaId) }` (radius from `area:meta`).
+5. `prev = SMEMBERS geofence:inside:{userId}`.
+6. **Enters:** for `areaId ∈ nowInside \ prev` → `SADD inside`,
+   `HDEL pending-exit areaId`, emit `('entered', areaId, tst)`.
+7. **Exits / cushion:** for each `areaId ∈ prev`:
+   - still in `nowInside` → `HDEL pending-exit areaId` (came back / never left); no event.
+   - outside & no pending timer → `HSET pending-exit areaId = tst`; no event.
+   - outside & `tst - pendingSince >= thresholdSeconds` → `SREM inside`,
+     `HDEL pending-exit`, emit `('exited', areaId, tst)`.
+   - outside & within cushion → no event (stays "inside" until confirmed).
+8. Return the flat event list; the adapter maps it to typed `GeofenceEvent`s.
+
+This yields the required semantics: no duplicate enters, no exit until ≥ threshold
+seconds continuously outside, and re-entry within the cushion silently cancels the
+pending exit (no exit, no re-enter).
+
+---
+
+## Domain & Ports (new / changed)
+
+**`@/domain/types.ts`** — add:
+
+- `Area = { id: string; userId: string; name: string; lat: number; lon: number; radius: number }`
+  (JSDoc each field to match the file's style). The pre-existing unused
+  `Geofence = { waypoint; isInside }` type is waypoint-shaped and won't be reused;
+  leave it or remove it — it does not model our per-user `Area`.
+
+**`@/domain/schemas.ts`** — add `AreaSchema` (Zod: `lat` ∈ [-90,90], `lon` ∈
+[-180,180], `radius` > 0, `userId`/`id`/`name` non-empty) for validating
+the area-management API input. Follows the hand-maintained schema convention.
+
+**`@/domain/events.ts`** (re-introduce; was removed in a prior refactor):
+
+- `PubSubEvent = { _type: string }`
+- `AreaEnteredEvent = PubSubEvent & { _type: 'area.entered'; userId; areaId; areaName?; lat; lon; tst }`
+- `AreaExitedEvent = PubSubEvent & { _type: 'area.exited'; ... same shape ... }`
+- `GeofenceEvent = AreaEnteredEvent | AreaExitedEvent`
+- `DomainEvent = GeofenceEvent` (union kept open for future events)
+
+Naming follows `.claude/skills/naming` — `<Subject><VerbPast>Event` types with
+`<entity>.<verb>` `_type` strings.
+
+**`@/domain/ports.ts`** — add:
+
+- `AreaRepository` — `addArea`, `removeArea`, `listAreas`, `getArea`, `healthCheck`.
+- `GeofenceEvaluator` — `evaluate(userId: string, lon: number, lat: number, tst: number): Promise<GeofenceEvent[]>`.
+- `EventPublisher` — `publish(event: DomainEvent): void | Promise<void>` (re-add; closes #6).
+- `saveAreaEvent(event: GeofenceEvent): void | Promise<void>` added to the existing
+  `LocationRepository` interface (mirrors how `saveTransition` lives there).
+- `NotificationSender` already exists — no change to the interface.
+
+---
+
+## Infrastructure & Repository Adapters (new files)
+
+Following existing naming (`kebab.role.ts`, `class QualifierRole`):
+
+| File | Class | Implements |
+| --- | --- | --- |
+| `@/infrastructure/redis/client.ts` | `createRedisClient(url)` factory (`Bun.RedisClient`) | — |
+| `@/repository/area-repository/redis.repository.ts` | `RedisAreaRepository` | `AreaRepository` |
+| `@/infrastructure/geofence/redis.geofence-evaluator.ts` | `RedisGeofenceEvaluator` | `GeofenceEvaluator` |
+| `@/infrastructure/geofence/geofence.lua.ts` | the Lua source string + `SHA` load/eval helper | — |
+| `@/infrastructure/events/redis.event-publisher.ts` | `RedisEventPublisher` (PUBLISH JSON) | `EventPublisher` |
+| `@/infrastructure/events/db.event-publisher.ts` | `DbEventPublisher` (→ `repo.saveAreaEvent`) | `EventPublisher` |
+| `@/infrastructure/events/notification.event-publisher.ts` | `NotificationEventPublisher` (formats subject/body) | `EventPublisher` |
+| `@/infrastructure/events/composite.event-publisher.ts` | `CompositeEventPublisher` (fan-out, per-sink try/catch) | `EventPublisher` |
+| `@/infrastructure/notifications/log.notification-sender.ts` | `LogNotificationSender` (logs the alert) | `NotificationSender` |
+
+- Use **`Bun.redis` / `Bun.RedisClient`** and issue GEO/EVAL/PUBLISH via the
+  client's generic `.send(command, args)` (CLAUDE.md: `Bun.redis`, not `ioredis`).
+- `LogNotificationSender` is the initial concrete `NotificationSender` (there's no
+  email/push channel today); it's the seam where a real push/email/MQTT sender
+  drops in later.
+- `CompositeEventPublisher` wraps each sink in its own `try/catch` so one failing
+  sink (e.g. Redis down) never blocks the others or the request.
+
+---
+
+## Wiring, Handlers, and API changes
+
+**`@/application/handle-payload.ts`** — widen `Deps`:
+`{ repo, logger, decryptor, reverseGeocoder, geofence: GeofenceEvaluator, eventPublisher: EventPublisher }`.
+
+**`@/application/handlers/location.handler.ts`** — widen its `deps` slice to include
+`geofence` + `eventPublisher`. After `await deps.repo.saveLocation(payload)`:
+`const events = await deps.geofence.evaluate(payload.tid, payload.lon, payload.lat, payload.tst);`
+then `for (const e of events) await deps.eventPublisher.publish(e);`. Evaluation is
+awaited (fast `EVALSHA`); a failing evaluate is caught and logged so it never drops
+the location save.
+
+**`@/entrypoints/http.ts`** (composition root) — in _both_ the Postgres and SQLite
+branches: build `const redis = createRedisClient(config.redisUrl)`; construct
+`RedisAreaRepository`, `RedisGeofenceEvaluator`, the three sink publishers wrapped
+in a `CompositeEventPublisher`, and a `LogNotificationSender`; add `geofence` +
+`eventPublisher` (and pass `areaRepo` to the server for the management routes) to
+`deps`.
+
+**Area management surface** — areas are "predefined," so we need a way to define
+them. Add minimal CRUD routes to `@/infrastructure/http/server.ts` backed by
+`AreaRepository`, validated with `AreaSchema`:
+
+- `POST /areas` → create/replace an area for a user.
+- `GET /areas/:userId` → list a user's areas.
+- `DELETE /areas/:userId/:areaId` → remove one.
+
+(Alternative: a one-off seed script under `scripts/`. Recommendation: the HTTP
+routes, since they reuse the running server and `AreaRepository`.)
+
+---
+
+## Config & Deployment
+
+**`@/config.ts`** (+ `@/config.test.ts`) — add two env vars in all three spots
+(schema, `Config` type, `loadConfig` destructure/return), and add the new keys to
+`config.test.ts`'s `envKeys` array plus default/override assertions:
+
+- `REDIS_URL` → `redisUrl` (default `redis://localhost:6379`).
+- `GEOFENCE_EXIT_THRESHOLD_SECONDS` → `geofenceExitThresholdSeconds`
+  (`z.coerce.number()`, default `60`).
+
+**Docker** — add a `redis` service to `compose.yaml` and `docker-compose.dev.yml`
+(`redis:7-alpine`, command `redis-server --appendonly yes`, a named volume for AOF
+persistence so predefined areas survive restarts), and pass `REDIS_URL` to the
+`http` service. (Follow `.claude/skills/create-dockerfile` only if a Dockerfile
+itself changes — here it's compose services.)
+
+---
+
+## Use Cases / Scenarios to Support (and test)
+
+Grouped as core enter/exit, multiplicity, robustness, lifecycle, and fan-out
+(kept as one numbered list so the cross-references below stay stable).
+
+1. **Enter (core):** location moves from outside → inside an area ⇒ one
+   `area.entered`.
+2. **Stay inside:** repeated locations inside ⇒ no duplicate enter events.
+3. **Brief exit within cushion:** outside for < threshold then back inside ⇒
+   **no** exit and **no** re-enter (pending exit silently cancelled).
+4. **Confirmed exit:** continuously outside ≥ threshold, next location past the
+   cushion ⇒ one `area.exited`.
+5. **Cold start:** a user's first-ever location, already inside an area ⇒ enter
+   fires (no prior state).
+6. **Per-user isolation (multiplicity):** two users at identical coordinates get
+   results based only on their own areas; user A's areas never affect user B.
+7. **Overlapping areas:** a point inside two areas ⇒ two enter events; leaving one
+   but staying in the other ⇒ one exit only.
+8. **Boundary:** point exactly at `distance == radius` counts as inside
+   (inclusive); just beyond does not.
+9. **GPS jitter (robustness):** `stationaryCoordinates` fixture inside an area ⇒
+   no spurious enter/exit churn.
+10. **Path crossing:** `walkingCoordinates` / `drivingCoordinates` crossing an
+    area boundary ⇒ exactly one enter then one exit, in order.
+11. **No areas / empty user:** locations for a user with zero areas ⇒ no events,
+    no errors.
+12. **Sparse updates limitation:** exit is only evaluated on the next location
+    after the cushion elapses; if the device stops reporting, the exit is delayed
+    (documented; not a bug).
+13. **Add / remove area (lifecycle):** add then a location inside ⇒ enter fires;
+    remove ⇒ no further events and its inside/pending state is cleaned up.
+14. **Radius change:** remove + re-add ⇒ membership recomputed against new radius.
+15. **Event fan-out:** each emitted event is **published to Redis Pub/Sub**,
+    **persisted to `area_events`**, and **routed to `NotificationSender`**; a
+    failure in one sink does not block the others or the location save.
+
+---
+
+## Persistence for event audit (DB sink)
+
+Add an `area_events` table to both stores (mirrors the `transitions` table):
+
+- **SQLite:** new `sqliteTable('area_events', ...)` in
+  `@/infrastructure/persistence/schema.ts` + a new `drizzle/000X_*.sql` migration
+  (columns: `id`, `type`, `user_id`, `area_id`, `area_name`, `lat`, `lon`, `tst`,
+  `created_at`).
+- **Postgres:** add the `CREATE TABLE IF NOT EXISTS area_events (...)` to
+  `PostgresLocationRepository.migrate()`.
+- Implement `saveAreaEvent` in both `SqliteLocationRepository` (sync) and
+  `PostgresLocationRepository` (async), consumed by `DbEventPublisher`.
+
+---
+
+## Testing Plan (`bun test`)
+
+**Test utilities** (`@/test/`): add `buildArea()` to `factories.ts`;
+`mockAreaRepository()`, `mockGeofenceEvaluator()`, `mockEventPublisher()`,
+`mockNotificationSender` (exists) to `mocks.ts`. Reuse `coordinates.ts` fixtures
+(`stationaryCoordinates`, `walkingCoordinates`, `drivingCoordinates`) for
+path/jitter scenarios.
+
+**Unit tests:**
+
+- `location.handler.test.ts`: with a mock evaluator returning events, asserts each
+  event is published; evaluate failure is caught and the location still saves.
+- `composite.event-publisher.test.ts`: fan-out reaches all sinks; one throwing sink
+  doesn't stop the rest.
+- `notification.event-publisher.test.ts`: correct subject/body formatting per event.
+- `config.test.ts`: `REDIS_URL` / `GEOFENCE_EXIT_THRESHOLD_SECONDS` defaults +
+  overrides.
+
+**Integration tests** (real Redis, guarded by `describe.skipIf(!REDIS_URL)` so CI
+without Redis still passes — mirrors the real-infra style of `server.test.ts` which
+boots a real SQLite DB): `redis.geofence.test.ts` exercises `RedisAreaRepository` +
+`RedisGeofenceEvaluator` against a live Redis, covering use cases 1–14 by adding
+areas and feeding coordinate sequences with controlled `tst` values to drive the
+cushion timing. `beforeEach` flushes the test keyspace.
+
+---
+
+## Verification (end-to-end)
+
+1. `docker compose -f docker-compose.dev.yml up -d redis` (or run `redis-server
+   --appendonly yes` locally).
+2. `bun test` — all unit + (Redis-guarded) integration tests green. Per project
+   memory, review any `oxfmt` diffs for corrupted numeric literals in the
+   coordinate/area fixtures.
+3. Start the server: `bun run <http entrypoint>` with `REDIS_URL` set.
+4. Define an area: `POST /areas` with `{ userId: "AB", lat, lon, radius }`.
+5. In one terminal, `redis-cli SUBSCRIBE geofence:events` (or the chosen channel).
+6. `POST /pub` a `location` (`tid: "AB"`) **inside** the area ⇒ observe an
+   `area.entered` on the channel, a row in `area_events`, and a
+   `LogNotificationSender` log line.
+7. `POST /pub` a location **outside**, then another outside with `tst` ≥ 60s later
+   ⇒ observe exactly one `area.exited`. Send an intermediate "back inside" location
+   before 60s to confirm the exit is suppressed.
+8. Restart Redis and confirm areas persist (AOF), i.e. `GET /areas/AB` still lists
+   them.
+
+---
+
+## Out of Scope / Future Work
+
+- **Background exit sweeper** (worker process) to fire exits when a device goes
+  silent — deferred per decision #3; the `worker.ts` stub is the natural home.
+- **MQTT ingestion** path (stub) — geofencing hooks into `handlePayload`, so it
+  will work automatically once MQTT ingestion is implemented.
+- **Polygon geofences** — this plan is circular-only, as the issue specifies.
+- **Auth on `/pub` and `/areas`** — user identity currently trusts `tid`.
+
+---
+
+## Files Touched (summary)
+
+- **New:** `@/domain/events.ts`; `@/infrastructure/redis/client.ts`;
+  `@/repository/area-repository/redis.repository.ts`;
+  `@/infrastructure/geofence/{redis.geofence-evaluator.ts, geofence.lua.ts}`;
+  `@/infrastructure/events/{redis,db,notification,composite}.event-publisher.ts`;
+  `@/infrastructure/notifications/log.notification-sender.ts`; new `drizzle/*.sql`;
+  test files listed above.
+- **Changed:** `@/domain/{types.ts, schemas.ts, ports.ts}`;
+  `@/application/handle-payload.ts`; `@/application/handlers/location.handler.ts`;
+  `@/entrypoints/http.ts`; `@/infrastructure/http/server.ts`;
+  `@/infrastructure/persistence/schema.ts`;
+  `@/repository/location-repository/{sqlite,postgres}.repository.ts`;
+  `@/config.ts` (+ `config.test.ts`); `compose.yaml`; `docker-compose.dev.yml`;
+  `@/test/{factories.ts, mocks.ts}`.

--- a/drizzle/0003_kind_hedge_knight.sql
+++ b/drizzle/0003_kind_hedge_knight.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `area_events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`type` text NOT NULL,
+	`user_id` text NOT NULL,
+	`area_id` text NOT NULL,
+	`area_name` text,
+	`lat` real NOT NULL,
+	`lon` real NOT NULL,
+	`tst` integer NOT NULL,
+	`created_at` text DEFAULT (datetime('now'))
+);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,465 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ede68abf-a72a-44d9-9755-bd08386b9b77",
+  "prevId": "4551bb8c-748e-46f3-b4e5-4c6e5b30f2d5",
+  "tables": {
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lon": {
+          "name": "lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "area_events": {
+      "name": "area_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "area_name": {
+          "name": "area_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lon": {
+          "name": "lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tst": {
+          "name": "tst",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lon": {
+          "name": "lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tst": {
+          "name": "tst",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tid": {
+          "name": "tid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acc": {
+          "name": "acc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "batt": {
+          "name": "batt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vel": {
+          "name": "vel",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conn": {
+          "name": "conn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transitions": {
+      "name": "transitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tst": {
+          "name": "tst",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wtst": {
+          "name": "wtst",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acc": {
+          "name": "acc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lon": {
+          "name": "lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tid": {
+          "name": "tid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desc": {
+          "name": "desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "t": {
+          "name": "t",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waypoints": {
+      "name": "waypoints",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "desc": {
+          "name": "desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tst": {
+          "name": "tst",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lon": {
+          "name": "lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rad": {
+          "name": "rad",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minor": {
+          "name": "minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1770742801748,
       "tag": "0002_young_black_widow",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1783471413121,
+      "tag": "0003_kind_hedge_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/application/handle-payload.ts
+++ b/src/application/handle-payload.ts
@@ -1,5 +1,13 @@
 import type { OwnTracksPayload } from '@/domain/types.ts';
-import type { Geocoder, LocationRepository, Logger, PayloadDecryptor } from '@/domain/ports.ts';
+import type {
+  AreaRepository,
+  EventPublisher,
+  Geocoder,
+  GeofenceEvaluator,
+  LocationRepository,
+  Logger,
+  PayloadDecryptor,
+} from '@/domain/ports.ts';
 import { handleLocation } from '@/application/handlers/location.handler.ts';
 import { handleTransition } from '@/application/handlers/transition.handler.ts';
 import { handleWaypoint } from '@/application/handlers/waypoint.handler.ts';
@@ -10,6 +18,9 @@ export interface Deps {
   logger: Logger;
   decryptor: PayloadDecryptor;
   reverseGeocoder: Geocoder;
+  geofence: GeofenceEvaluator;
+  eventPublisher: EventPublisher;
+  areaRepo: AreaRepository;
 }
 
 export async function handlePayload(payload: OwnTracksPayload, deps: Deps): Promise<void> {

--- a/src/application/handlers/location.handler.test.ts
+++ b/src/application/handlers/location.handler.test.ts
@@ -1,0 +1,86 @@
+import { test, expect, describe } from 'bun:test';
+import { handleLocation } from '@/application/handlers/location.handler.ts';
+import {
+  mockEventPublisher,
+  mockGeocoder,
+  mockGeofenceEvaluator,
+  mockLocationRepository,
+  mockLogger,
+} from '@/test/mocks.ts';
+import { buildLocationPayload } from '@/test/factories.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
+
+describe('handleLocation', () => {
+  test('publishes every event returned by the geofence evaluator', async () => {
+    const events: GeofenceEvent[] = [
+      {
+        _type: 'area.entered',
+        userId: 'AB',
+        areaId: 'area-1',
+        areaName: 'Home',
+        lat: 42.3601,
+        lon: -71.0589,
+        tst: 1700000000,
+      },
+      {
+        _type: 'area.exited',
+        userId: 'AB',
+        areaId: 'area-2',
+        lat: 42.3601,
+        lon: -71.0589,
+        tst: 1700000000,
+      },
+    ];
+
+    const repo = mockLocationRepository();
+    const geofence = mockGeofenceEvaluator();
+    geofence.evaluate.mockResolvedValue(events);
+    const eventPublisher = mockEventPublisher();
+
+    await handleLocation(buildLocationPayload(), {
+      repo,
+      logger: mockLogger(),
+      reverseGeocoder: mockGeocoder(),
+      geofence,
+      eventPublisher,
+    });
+
+    expect(eventPublisher.publish).toHaveBeenCalledTimes(2);
+    expect(eventPublisher.publish).toHaveBeenNthCalledWith(1, events[0]);
+    expect(eventPublisher.publish).toHaveBeenNthCalledWith(2, events[1]);
+  });
+
+  test('saves the location even when geofence evaluation throws', async () => {
+    const repo = mockLocationRepository();
+    const geofence = mockGeofenceEvaluator();
+    geofence.evaluate.mockRejectedValue(new Error('redis down'));
+    const eventPublisher = mockEventPublisher();
+    const logger = mockLogger();
+
+    await handleLocation(buildLocationPayload(), {
+      repo,
+      logger,
+      reverseGeocoder: mockGeocoder(),
+      geofence,
+      eventPublisher,
+    });
+
+    expect(repo.saveLocation).toHaveBeenCalledTimes(1);
+    expect(eventPublisher.publish).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test('evaluates geofence with the payload tid, lon, lat, and tst', async () => {
+    const geofence = mockGeofenceEvaluator();
+
+    await handleLocation(buildLocationPayload({ tid: 'AB', lat: 1, lon: 2, tst: 3 }), {
+      repo: mockLocationRepository(),
+      logger: mockLogger(),
+      reverseGeocoder: mockGeocoder(),
+      geofence,
+      eventPublisher: mockEventPublisher(),
+    });
+
+    expect(geofence.evaluate).toHaveBeenCalledWith('AB', 2, 1, 3);
+  });
+});

--- a/src/application/handlers/location.handler.ts
+++ b/src/application/handlers/location.handler.ts
@@ -1,9 +1,21 @@
 import type { LocationPayload } from '@/domain/types.ts';
-import type { Geocoder, LocationRepository, Logger } from '@/domain/ports.ts';
+import type {
+  EventPublisher,
+  Geocoder,
+  GeofenceEvaluator,
+  LocationRepository,
+  Logger,
+} from '@/domain/ports.ts';
 
 export async function handleLocation(
   payload: LocationPayload,
-  deps: { repo: LocationRepository; logger: Logger; reverseGeocoder: Geocoder },
+  deps: {
+    repo: LocationRepository;
+    logger: Logger;
+    reverseGeocoder: Geocoder;
+    geofence: GeofenceEvaluator;
+    eventPublisher: EventPublisher;
+  },
 ): Promise<void> {
   deps.logger.info(`Location received for tid=${payload.tid}`);
   deps.reverseGeocoder
@@ -18,4 +30,13 @@ export async function handleLocation(
       deps.logger.error(`Reverse geocode failed: ${err}`);
     });
   await deps.repo.saveLocation(payload);
+
+  try {
+    const events = await deps.geofence.evaluate(payload.tid, payload.lon, payload.lat, payload.tst);
+    for (const event of events) {
+      await deps.eventPublisher.publish(event);
+    }
+  } catch (err) {
+    deps.logger.error(`Geofence evaluation failed: ${err}`);
+  }
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -15,6 +15,8 @@ describe('loadConfig', () => {
     'POSTGRES_PASSWORD',
     'POSTGRES_DB',
     'ENCRYPTION_KEY',
+    'REDIS_URL',
+    'GEOFENCE_EXIT_THRESHOLD_SECONDS',
   ] as const;
 
   beforeEach(() => {
@@ -49,6 +51,8 @@ describe('loadConfig', () => {
     expect(config.postgresPassword).toBeUndefined();
     expect(config.postgresDb).toBe('location_tracker');
     expect(config.encryptionKey).toBe(validEncryptionKey);
+    expect(config.redisUrl).toBe('redis://localhost:6379');
+    expect(config.geofenceExitThresholdSeconds).toBe(60);
   });
 
   test('returns custom values from env vars', () => {
@@ -62,6 +66,8 @@ describe('loadConfig', () => {
     process.env.POSTGRES_PASSWORD = 'secret';
     process.env.POSTGRES_DB = 'mydb';
     process.env.ENCRYPTION_KEY = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    process.env.REDIS_URL = 'redis://redis.example.com:6380';
+    process.env.GEOFENCE_EXIT_THRESHOLD_SECONDS = '120';
 
     const config = loadConfig();
 
@@ -75,6 +81,8 @@ describe('loadConfig', () => {
     expect(config.postgresPassword).toBe('secret');
     expect(config.postgresDb).toBe('mydb');
     expect(config.encryptionKey).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(config.redisUrl).toBe('redis://redis.example.com:6380');
+    expect(config.geofenceExitThresholdSeconds).toBe(120);
   });
 
   test('throws when ENCRYPTION_KEY is missing', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ const ConfigSchema = z.object({
     .refine((key) => encryptionKeyByteLength(key) === SECRETBOX_KEY_BYTES, {
       message: `ENCRYPTION_KEY must be ${SECRETBOX_KEY_BYTES} bytes`,
     }),
+  REDIS_URL: z.string().default('redis://localhost:6379'),
+  GEOFENCE_EXIT_THRESHOLD_SECONDS: z.coerce.number().default(60),
 });
 
 export type Config = {
@@ -44,6 +46,8 @@ export type Config = {
   postgresPassword?: string;
   postgresDb: string;
   encryptionKey: string;
+  redisUrl: string;
+  geofenceExitThresholdSeconds: number;
 };
 
 export function loadConfig(): Config {
@@ -58,6 +62,8 @@ export function loadConfig(): Config {
     POSTGRES_PASSWORD,
     POSTGRES_DB,
     ENCRYPTION_KEY,
+    REDIS_URL,
+    GEOFENCE_EXIT_THRESHOLD_SECONDS,
   } = process.env;
   const env = ConfigSchema.parse({
     NODE_ENV,
@@ -70,6 +76,8 @@ export function loadConfig(): Config {
     POSTGRES_PASSWORD,
     POSTGRES_DB,
     ENCRYPTION_KEY,
+    REDIS_URL,
+    GEOFENCE_EXIT_THRESHOLD_SECONDS,
   });
   return {
     nodeEnv: env.NODE_ENV,
@@ -82,5 +90,7 @@ export function loadConfig(): Config {
     postgresPassword: env.POSTGRES_PASSWORD,
     postgresDb: env.POSTGRES_DB,
     encryptionKey: env.ENCRYPTION_KEY,
+    redisUrl: env.REDIS_URL,
+    geofenceExitThresholdSeconds: env.GEOFENCE_EXIT_THRESHOLD_SECONDS,
   };
 }

--- a/src/domain/events.ts
+++ b/src/domain/events.ts
@@ -1,0 +1,27 @@
+export type PubSubEvent = {
+  _type: string;
+};
+
+export type AreaEnteredEvent = PubSubEvent & {
+  _type: 'area.entered';
+  userId: string;
+  areaId: string;
+  areaName?: string;
+  lat: number;
+  lon: number;
+  tst: number;
+};
+
+export type AreaExitedEvent = PubSubEvent & {
+  _type: 'area.exited';
+  userId: string;
+  areaId: string;
+  areaName?: string;
+  lat: number;
+  lon: number;
+  tst: number;
+};
+
+export type GeofenceEvent = AreaEnteredEvent | AreaExitedEvent;
+
+export type DomainEvent = GeofenceEvent;

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -1,10 +1,12 @@
 import type {
   Address,
+  Area,
   GeocodingResult,
   LocationPayload,
   TransitionPayload,
   WaypointPayload,
 } from '@/domain/types.ts';
+import type { DomainEvent, GeofenceEvent } from '@/domain/events.ts';
 
 export interface LocationService {
   saveLocation(payload: LocationPayload): void | Promise<void>;
@@ -17,7 +19,24 @@ export interface LocationRepository {
   saveTransition(payload: TransitionPayload): void | Promise<void>;
   saveWaypoint(payload: WaypointPayload): void | Promise<void>;
   saveAddress(lat: number, lon: number, address: Address): void | Promise<void>;
+  saveAreaEvent(event: GeofenceEvent): void | Promise<void>;
   healthCheck(): Promise<void>;
+}
+
+export interface AreaRepository {
+  addArea(area: Area): void | Promise<void>;
+  removeArea(userId: string, areaId: string): void | Promise<void>;
+  listAreas(userId: string): Promise<Area[]>;
+  getArea(userId: string, areaId: string): Promise<Area | undefined>;
+  healthCheck(): Promise<void>;
+}
+
+export interface GeofenceEvaluator {
+  evaluate(userId: string, lon: number, lat: number, tst: number): Promise<GeofenceEvent[]>;
+}
+
+export interface EventPublisher {
+  publish(event: DomainEvent): void | Promise<void>;
 }
 
 export interface Logger {

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -162,3 +162,12 @@ export const OwnTracksPayloadSchema = z.discriminatedUnion('_type', [
   CmdPayloadSchema,
   RequestPayloadSchema,
 ]);
+
+export const AreaSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  name: z.string().min(1),
+  lat: z.number().min(-90).max(90),
+  lon: z.number().min(-180).max(180),
+  radius: z.number().positive(),
+});

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -286,3 +286,14 @@ export type GeocodingResult = {
   lat: number;
   lon: number;
 };
+
+/** A predefined circular geofence owned by a single user. */
+export type Area = {
+  id: string;
+  userId: string;
+  name: string;
+  lat: number;
+  lon: number;
+  /** Radius in meters. */
+  radius: number;
+};

--- a/src/entrypoints/http.ts
+++ b/src/entrypoints/http.ts
@@ -29,7 +29,7 @@ const decryptor = await LibsodiumDecryptor.create(
   Buffer.from(btoa(config.encryptionKey), 'base64'),
 );
 
-const redis = createRedisClient(config.redisUrl);
+const redis = createRedisClient();
 const areaRepo = new RedisAreaRepository(redis);
 const geofence = new RedisGeofenceEvaluator(redis, config.geofenceExitThresholdSeconds);
 const notificationSender = new LogNotificationSender(logger);

--- a/src/entrypoints/http.ts
+++ b/src/entrypoints/http.ts
@@ -11,6 +11,15 @@ import { PostgresLocationRepository } from '@/repository/location-repository/pos
 import { NominatimGeocoder } from '@/infrastructure/geocoder/nominatim.geocoder';
 import { CoordinatePrecision } from '@/domain/types';
 import type { Deps } from '@/application/handle-payload.ts';
+import { createRedisClient } from '@/infrastructure/redis/client.ts';
+import { RedisAreaRepository } from '@/repository/area-repository/redis.repository.ts';
+import { RedisGeofenceEvaluator } from '@/infrastructure/geofence/redis.geofence-evaluator.ts';
+import { RedisEventPublisher } from '@/infrastructure/events/redis.event-publisher.ts';
+import { DbEventPublisher } from '@/infrastructure/events/db.event-publisher.ts';
+import { NotificationEventPublisher } from '@/infrastructure/events/notification.event-publisher.ts';
+import { CompositeEventPublisher } from '@/infrastructure/events/composite.event-publisher.ts';
+import { LogNotificationSender } from '@/infrastructure/notifications/log.notification-sender.ts';
+import type { LocationRepository } from '@/domain/ports.ts';
 
 const config = loadConfig();
 const logger = new PinoLogger();
@@ -19,6 +28,22 @@ const reverseGeocoder = new NominatimGeocoder(CoordinatePrecision.Building);
 const decryptor = await LibsodiumDecryptor.create(
   Buffer.from(btoa(config.encryptionKey), 'base64'),
 );
+
+const redis = createRedisClient(config.redisUrl);
+const areaRepo = new RedisAreaRepository(redis);
+const geofence = new RedisGeofenceEvaluator(redis, config.geofenceExitThresholdSeconds);
+const notificationSender = new LogNotificationSender(logger);
+
+function buildEventPublisher(repo: LocationRepository) {
+  return new CompositeEventPublisher(
+    [
+      new RedisEventPublisher(redis),
+      new DbEventPublisher(repo),
+      new NotificationEventPublisher(notificationSender),
+    ],
+    logger,
+  );
+}
 
 let deps: Deps;
 
@@ -40,15 +65,22 @@ if (config.postgresPassword !== undefined) {
     logger,
     decryptor,
     reverseGeocoder,
+    geofence,
+    eventPublisher: buildEventPublisher(repo),
+    areaRepo,
   };
 } else {
   const db = new Database(config.dbPath, { create: true });
   runMigrations(db);
+  const repo = new SqliteLocationRepository(db);
   deps = {
-    repo: new SqliteLocationRepository(db),
+    repo,
     logger,
     decryptor,
     reverseGeocoder,
+    geofence,
+    eventPublisher: buildEventPublisher(repo),
+    areaRepo,
   };
 }
 

--- a/src/infrastructure/events/composite.event-publisher.test.ts
+++ b/src/infrastructure/events/composite.event-publisher.test.ts
@@ -1,0 +1,42 @@
+import { test, expect, describe, mock } from 'bun:test';
+import { CompositeEventPublisher } from '@/infrastructure/events/composite.event-publisher.ts';
+import { mockLogger } from '@/test/mocks.ts';
+import type { EventPublisher } from '@/domain/ports.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
+
+const event: GeofenceEvent = {
+  _type: 'area.entered',
+  userId: 'AB',
+  areaId: 'area-1',
+  lat: 42.3601,
+  lon: -71.0589,
+  tst: 1700000000,
+};
+
+describe('CompositeEventPublisher', () => {
+  test('fans out the event to every sink', async () => {
+    const sinkA: EventPublisher = { publish: mock(() => Promise.resolve()) };
+    const sinkB: EventPublisher = { publish: mock(() => Promise.resolve()) };
+
+    const composite = new CompositeEventPublisher([sinkA, sinkB], mockLogger());
+    await composite.publish(event);
+
+    expect(sinkA.publish).toHaveBeenCalledWith(event);
+    expect(sinkB.publish).toHaveBeenCalledWith(event);
+  });
+
+  test('a throwing sink does not stop the others from being called', async () => {
+    const failing: EventPublisher = {
+      publish: mock(() => Promise.reject(new Error('sink down'))),
+    };
+    const succeeding: EventPublisher = { publish: mock(() => Promise.resolve()) };
+    const logger = mockLogger();
+
+    const composite = new CompositeEventPublisher([failing, succeeding], logger);
+    await composite.publish(event);
+
+    expect(failing.publish).toHaveBeenCalledWith(event);
+    expect(succeeding.publish).toHaveBeenCalledWith(event);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/infrastructure/events/composite.event-publisher.ts
+++ b/src/infrastructure/events/composite.event-publisher.ts
@@ -1,0 +1,24 @@
+import type { DomainEvent } from '@/domain/events.ts';
+import type { EventPublisher, Logger } from '@/domain/ports.ts';
+
+export class CompositeEventPublisher implements EventPublisher {
+  private sinks: EventPublisher[];
+  private logger: Logger;
+
+  constructor(sinks: EventPublisher[], logger: Logger) {
+    this.sinks = sinks;
+    this.logger = logger;
+  }
+
+  async publish(event: DomainEvent): Promise<void> {
+    await Promise.all(
+      this.sinks.map(async (sink) => {
+        try {
+          await sink.publish(event);
+        } catch (err) {
+          this.logger.error('Event sink failed to publish', err);
+        }
+      }),
+    );
+  }
+}

--- a/src/infrastructure/events/db.event-publisher.ts
+++ b/src/infrastructure/events/db.event-publisher.ts
@@ -1,0 +1,14 @@
+import type { DomainEvent } from '@/domain/events.ts';
+import type { EventPublisher, LocationRepository } from '@/domain/ports.ts';
+
+export class DbEventPublisher implements EventPublisher {
+  private repo: LocationRepository;
+
+  constructor(repo: LocationRepository) {
+    this.repo = repo;
+  }
+
+  async publish(event: DomainEvent): Promise<void> {
+    await this.repo.saveAreaEvent(event);
+  }
+}

--- a/src/infrastructure/events/notification.event-publisher.test.ts
+++ b/src/infrastructure/events/notification.event-publisher.test.ts
@@ -1,0 +1,49 @@
+import { test, expect, describe } from 'bun:test';
+import { NotificationEventPublisher } from '@/infrastructure/events/notification.event-publisher.ts';
+import { mockNotificationSender } from '@/test/mocks.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
+
+describe('NotificationEventPublisher', () => {
+  test('formats subject/body for an entered event using the area name', async () => {
+    const notificationSender = mockNotificationSender();
+    const publisher = new NotificationEventPublisher(notificationSender);
+
+    const event: GeofenceEvent = {
+      _type: 'area.entered',
+      userId: 'AB',
+      areaId: 'area-1',
+      areaName: 'Home',
+      lat: 42.3601,
+      lon: -71.0589,
+      tst: 1700000000,
+    };
+
+    await publisher.publish(event);
+
+    expect(notificationSender.sendNotification).toHaveBeenCalledWith(
+      'AB entered Home',
+      'User AB entered area "Home" at 42.3601, -71.0589 (tst=1700000000)',
+    );
+  });
+
+  test('formats subject/body for an exited event, falling back to areaId when no name', async () => {
+    const notificationSender = mockNotificationSender();
+    const publisher = new NotificationEventPublisher(notificationSender);
+
+    const event: GeofenceEvent = {
+      _type: 'area.exited',
+      userId: 'CD',
+      areaId: 'area-2',
+      lat: 1,
+      lon: 2,
+      tst: 1700000100,
+    };
+
+    await publisher.publish(event);
+
+    expect(notificationSender.sendNotification).toHaveBeenCalledWith(
+      'CD exited area-2',
+      'User CD exited area "area-2" at 1, 2 (tst=1700000100)',
+    );
+  });
+});

--- a/src/infrastructure/events/notification.event-publisher.ts
+++ b/src/infrastructure/events/notification.event-publisher.ts
@@ -1,0 +1,19 @@
+import type { DomainEvent } from '@/domain/events.ts';
+import type { EventPublisher, NotificationSender } from '@/domain/ports.ts';
+
+export class NotificationEventPublisher implements EventPublisher {
+  private notificationSender: NotificationSender;
+
+  constructor(notificationSender: NotificationSender) {
+    this.notificationSender = notificationSender;
+  }
+
+  async publish(event: DomainEvent): Promise<void> {
+    const areaLabel = event.areaName ?? event.areaId;
+    const verb = event._type === 'area.entered' ? 'entered' : 'exited';
+    const subject = `${event.userId} ${verb} ${areaLabel}`;
+    const body = `User ${event.userId} ${verb} area "${areaLabel}" at ${event.lat}, ${event.lon} (tst=${event.tst})`;
+
+    await this.notificationSender.sendNotification(subject, body);
+  }
+}

--- a/src/infrastructure/events/redis.event-publisher.ts
+++ b/src/infrastructure/events/redis.event-publisher.ts
@@ -1,0 +1,17 @@
+import type { RedisClient } from 'bun';
+import type { DomainEvent } from '@/domain/events.ts';
+import type { EventPublisher } from '@/domain/ports.ts';
+
+const GEOFENCE_EVENTS_CHANNEL = 'geofence:events';
+
+export class RedisEventPublisher implements EventPublisher {
+  private redis: RedisClient;
+
+  constructor(redis: RedisClient) {
+    this.redis = redis;
+  }
+
+  async publish(event: DomainEvent): Promise<void> {
+    await this.redis.publish(GEOFENCE_EVENTS_CHANNEL, JSON.stringify(event));
+  }
+}

--- a/src/infrastructure/geofence/geofence.lua.ts
+++ b/src/infrastructure/geofence/geofence.lua.ts
@@ -1,0 +1,107 @@
+import type { RedisClient } from 'bun';
+import { createHash } from 'node:crypto';
+
+/**
+ * KEYS[1] = geo:areas:{userId}
+ * KEYS[2] = area:meta:{userId}
+ * KEYS[3] = area:maxradius:{userId}
+ * KEYS[4] = geofence:inside:{userId}
+ * KEYS[5] = geofence:pending-exit:{userId}
+ *
+ * ARGV[1] = userId
+ * ARGV[2] = lon
+ * ARGV[3] = lat
+ * ARGV[4] = tst
+ * ARGV[5] = thresholdSeconds
+ *
+ * Returns a flat array: { type, areaId, areaName, lat, lon, tst, ... }
+ * where type is "entered" or "exited".
+ */
+export const GEOFENCE_LUA_SCRIPT = `
+local geoAreasKey = KEYS[1]
+local areaMetaKey = KEYS[2]
+local maxRadiusKey = KEYS[3]
+local insideKey = KEYS[4]
+local pendingExitKey = KEYS[5]
+
+local userId = ARGV[1]
+local lon = tonumber(ARGV[2])
+local lat = tonumber(ARGV[3])
+local tst = tonumber(ARGV[4])
+local thresholdSeconds = tonumber(ARGV[5])
+
+local events = {}
+
+local maxRadius = redis.call('GET', maxRadiusKey)
+if not maxRadius then
+  return events
+end
+
+local candidates = redis.call('GEOSEARCH', geoAreasKey, 'FROMLONLAT', tostring(lon), tostring(lat), 'BYRADIUS', maxRadius, 'm', 'WITHDIST')
+
+local nowInside = {}
+for _, candidate in ipairs(candidates) do
+  local areaId = candidate[1]
+  local distance = tonumber(candidate[2])
+  local metaRaw = redis.call('HGET', areaMetaKey, areaId)
+  if metaRaw then
+    local meta = cjson.decode(metaRaw)
+    if distance <= meta.radius then
+      nowInside[areaId] = meta
+    end
+  end
+end
+
+local prev = redis.call('SMEMBERS', insideKey)
+local wasInside = {}
+for _, areaId in ipairs(prev) do
+  wasInside[areaId] = true
+end
+
+for areaId, meta in pairs(nowInside) do
+  if not wasInside[areaId] then
+    redis.call('SADD', insideKey, areaId)
+    redis.call('HDEL', pendingExitKey, areaId)
+    table.insert(events, { 'entered', areaId, meta.name, tostring(lat), tostring(lon), tostring(tst) })
+  end
+end
+
+for _, areaId in ipairs(prev) do
+  if nowInside[areaId] then
+    redis.call('HDEL', pendingExitKey, areaId)
+  else
+    local pendingSince = redis.call('HGET', pendingExitKey, areaId)
+    if not pendingSince then
+      redis.call('HSET', pendingExitKey, areaId, tostring(tst))
+    elseif (tst - tonumber(pendingSince)) >= thresholdSeconds then
+      redis.call('SREM', insideKey, areaId)
+      redis.call('HDEL', pendingExitKey, areaId)
+      local metaRaw = redis.call('HGET', areaMetaKey, areaId)
+      local areaName = ''
+      if metaRaw then
+        areaName = cjson.decode(metaRaw).name
+      end
+      table.insert(events, { 'exited', areaId, areaName, tostring(lat), tostring(lon), tostring(tst) })
+    end
+  end
+end
+
+return events
+`;
+
+const scriptSha = createHash('sha1').update(GEOFENCE_LUA_SCRIPT).digest('hex');
+
+export async function evalGeofenceScript(
+  redis: RedisClient,
+  keys: string[],
+  args: string[],
+): Promise<unknown> {
+  try {
+    return await redis.send('EVALSHA', [scriptSha, String(keys.length), ...keys, ...args]);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('NOSCRIPT')) {
+      return await redis.send('EVAL', [GEOFENCE_LUA_SCRIPT, String(keys.length), ...keys, ...args]);
+    }
+    throw err;
+  }
+}

--- a/src/infrastructure/geofence/redis.geofence-evaluator.ts
+++ b/src/infrastructure/geofence/redis.geofence-evaluator.ts
@@ -1,0 +1,58 @@
+import type { RedisClient } from 'bun';
+import type { GeofenceEvaluator } from '@/domain/ports.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
+import {
+  areaMaxRadiusKey,
+  areaMetaKey,
+  geoAreasKey,
+  geofenceInsideKey,
+  geofencePendingExitKey,
+} from '@/infrastructure/redis/keys.ts';
+import { evalGeofenceScript } from '@/infrastructure/geofence/geofence.lua.ts';
+
+type RawEvent = [
+  type: string,
+  areaId: string,
+  areaName: string,
+  lat: string,
+  lon: string,
+  tst: string,
+];
+
+export class RedisGeofenceEvaluator implements GeofenceEvaluator {
+  private redis: RedisClient;
+  private thresholdSeconds: number;
+
+  constructor(redis: RedisClient, thresholdSeconds: number) {
+    this.redis = redis;
+    this.thresholdSeconds = thresholdSeconds;
+  }
+
+  async evaluate(userId: string, lon: number, lat: number, tst: number): Promise<GeofenceEvent[]> {
+    const keys = [
+      geoAreasKey(userId),
+      areaMetaKey(userId),
+      areaMaxRadiusKey(userId),
+      geofenceInsideKey(userId),
+      geofencePendingExitKey(userId),
+    ];
+    const args = [userId, String(lon), String(lat), String(tst), String(this.thresholdSeconds)];
+
+    const rawEvents = (await evalGeofenceScript(this.redis, keys, args)) as RawEvent[];
+
+    return rawEvents.map(([type, areaId, areaName, eventLat, eventLon, eventTst]) => {
+      const base = {
+        userId,
+        areaId,
+        areaName: areaName || undefined,
+        lat: Number(eventLat),
+        lon: Number(eventLon),
+        tst: Number(eventTst),
+      };
+
+      return type === 'entered'
+        ? { _type: 'area.entered' as const, ...base }
+        : { _type: 'area.exited' as const, ...base };
+    });
+  }
+}

--- a/src/infrastructure/geofence/redis.geofence.test.ts
+++ b/src/infrastructure/geofence/redis.geofence.test.ts
@@ -1,0 +1,335 @@
+import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'bun:test';
+import type { RedisClient } from 'bun';
+import { Database } from 'bun:sqlite';
+import { createRedisClient } from '@/infrastructure/redis/client.ts';
+import { RedisAreaRepository } from '@/repository/area-repository/redis.repository.ts';
+import { RedisGeofenceEvaluator } from '@/infrastructure/geofence/redis.geofence-evaluator.ts';
+import { RedisEventPublisher } from '@/infrastructure/events/redis.event-publisher.ts';
+import { DbEventPublisher } from '@/infrastructure/events/db.event-publisher.ts';
+import { NotificationEventPublisher } from '@/infrastructure/events/notification.event-publisher.ts';
+import { CompositeEventPublisher } from '@/infrastructure/events/composite.event-publisher.ts';
+import { SqliteLocationRepository } from '@/repository/location-repository/sqlite.repository.ts';
+import { runMigrations } from '@/infrastructure/persistence/migrate.ts';
+import { buildArea } from '@/test/factories.ts';
+import { mockLogger, mockNotificationSender } from '@/test/mocks.ts';
+import { stationaryCoordinates, walkingCoordinates } from '@/test/coordinates.ts';
+import type { EventPublisher } from '@/domain/ports.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
+
+const REDIS_URL = process.env.REDIS_URL;
+const THRESHOLD_SECONDS = 60;
+
+describe.skipIf(!REDIS_URL)('RedisAreaRepository + RedisGeofenceEvaluator', () => {
+  let redis: RedisClient;
+  let areaRepo: RedisAreaRepository;
+  let geofence: RedisGeofenceEvaluator;
+  let userCounter = 0;
+
+  beforeAll(() => {
+    redis = createRedisClient(REDIS_URL!);
+    areaRepo = new RedisAreaRepository(redis);
+    geofence = new RedisGeofenceEvaluator(redis, THRESHOLD_SECONDS);
+  });
+
+  afterAll(() => {
+    redis.close();
+  });
+
+  beforeEach(async () => {
+    await redis.send('FLUSHDB', []);
+    userCounter += 1;
+  });
+
+  function nextUserId(): string {
+    return `user-${userCounter}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  test('1. enter: outside then inside yields exactly one area.entered', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const outside = await geofence.evaluate(userId, -71.2, 42.4, 1000);
+    expect(outside).toEqual([]);
+
+    const inside = await geofence.evaluate(userId, -71.1, 42.4, 1060);
+    expect(inside).toHaveLength(1);
+    expect(inside[0]).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+  });
+
+  test('2. stay inside: repeated inside locations produce no duplicate enters', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const first = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(first).toHaveLength(1);
+
+    const second = await geofence.evaluate(userId, -71.1, 42.4, 1060);
+    expect(second).toEqual([]);
+  });
+
+  test('3. brief exit within cushion: no exit and no re-enter', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const entered = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(entered).toHaveLength(1);
+
+    const outside = await geofence.evaluate(userId, -71.2, 42.4, 1010);
+    expect(outside).toEqual([]);
+
+    const backInside = await geofence.evaluate(userId, -71.1, 42.4, 1020);
+    expect(backInside).toEqual([]);
+  });
+
+  test('4. confirmed exit: continuously outside past the cushion yields one area.exited', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const entered = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(entered).toHaveLength(1);
+
+    const outsideStart = await geofence.evaluate(userId, -71.2, 42.4, 1010);
+    expect(outsideStart).toEqual([]);
+
+    const confirmedExit = await geofence.evaluate(
+      userId,
+      -71.2,
+      42.4,
+      1010 + THRESHOLD_SECONDS + 1,
+    );
+    expect(confirmedExit).toHaveLength(1);
+    expect(confirmedExit[0]).toMatchObject({ _type: 'area.exited', areaId: 'a1' });
+  });
+
+  test('5. cold start: first-ever location already inside fires enter', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const events = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+  });
+
+  test('6. per-user isolation: identical coordinates only trigger the owning user', async () => {
+    const userA = nextUserId();
+    const userB = nextUserId();
+    await areaRepo.addArea(
+      buildArea({ id: 'a1', userId: userA, lat: 42.4, lon: -71.1, radius: 100 }),
+    );
+
+    const eventsForA = await geofence.evaluate(userA, -71.1, 42.4, 1000);
+    expect(eventsForA).toHaveLength(1);
+
+    const eventsForB = await geofence.evaluate(userB, -71.1, 42.4, 1000);
+    expect(eventsForB).toEqual([]);
+  });
+
+  test('7. overlapping areas: two enters, then one exit when leaving only one', async () => {
+    const userId = nextUserId();
+    const center = { lat: 42.5, lon: -71.2 };
+    await areaRepo.addArea(
+      buildArea({ id: 'big', userId, lat: center.lat, lon: center.lon, radius: 300 }),
+    );
+    await areaRepo.addArea(
+      buildArea({ id: 'small', userId, lat: center.lat, lon: center.lon, radius: 100 }),
+    );
+
+    const bothEnter = await geofence.evaluate(userId, center.lon, center.lat, 1000);
+    expect(bothEnter).toHaveLength(2);
+    expect(bothEnter.map((e) => e.areaId).sort()).toEqual(['big', 'small']);
+
+    // ~150m north of center: inside "big" (radius 300), outside "small" (radius 100)
+    const farLat = center.lat + (150 / 6372797.560856) * (180 / Math.PI);
+
+    const pendingExit = await geofence.evaluate(userId, center.lon, farLat, 1070);
+    expect(pendingExit).toEqual([]);
+
+    const confirmedExit = await geofence.evaluate(
+      userId,
+      center.lon,
+      farLat,
+      1070 + THRESHOLD_SECONDS + 1,
+    );
+    expect(confirmedExit).toHaveLength(1);
+    expect(confirmedExit[0]).toMatchObject({ _type: 'area.exited', areaId: 'small' });
+  });
+
+  test('8. boundary: distance == radius counts as inside; just beyond does not', async () => {
+    const userId = nextUserId();
+    const center = { lat: 42.6, lon: -71.3 };
+    const probe = { lat: center.lat + 0.001, lon: center.lon };
+
+    // Measure via GEOSEARCH FROMLONLAT (not GEODIST) since that's the exact
+    // command the geofence Lua script uses for candidate distances — GEODIST
+    // between two stored members computes distance slightly differently and
+    // would not be self-consistent with what evaluate() actually measures.
+    const scratchKey = `test:scratch:${userId}`;
+    await redis.send('GEOADD', [scratchKey, String(center.lon), String(center.lat), 'center']);
+    const searchResult = (await redis.send('GEOSEARCH', [
+      scratchKey,
+      'FROMLONLAT',
+      String(probe.lon),
+      String(probe.lat),
+      'BYRADIUS',
+      '99999',
+      'm',
+      'WITHDIST',
+    ])) as [string, string][];
+    const distance = Number(searchResult.find(([member]) => member === 'center')![1]);
+    await redis.del(scratchKey);
+
+    await areaRepo.addArea(
+      buildArea({ id: 'inclusive', userId, lat: center.lat, lon: center.lon, radius: distance }),
+    );
+    await areaRepo.addArea(
+      buildArea({
+        id: 'exclusive',
+        userId,
+        lat: center.lat,
+        lon: center.lon,
+        radius: distance - 1,
+      }),
+    );
+
+    const events = await geofence.evaluate(userId, probe.lon, probe.lat, 1000);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ _type: 'area.entered', areaId: 'inclusive' });
+  });
+
+  test('9. GPS jitter: stationary coordinates produce no spurious churn', async () => {
+    const userId = nextUserId();
+    const center = stationaryCoordinates[0]!;
+    await areaRepo.addArea(
+      buildArea({ id: 'a1', userId, lat: center.lat, lon: center.lon, radius: 50 }),
+    );
+
+    const allEvents: GeofenceEvent[] = [];
+    for (const point of stationaryCoordinates) {
+      const events = await geofence.evaluate(userId, point.lon, point.lat, point.tst);
+      allEvents.push(...events);
+    }
+
+    expect(allEvents).toHaveLength(1);
+    expect(allEvents[0]).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+  });
+
+  test('10. path crossing: walking through an area yields exactly one enter then one exit', async () => {
+    const userId = nextUserId();
+    // Centered on walkingCoordinates[7]; points 6-8 fall within 100m, the rest do not.
+    await areaRepo.addArea(
+      buildArea({ id: 'a1', userId, lat: 42.356, lon: -71.0588, radius: 100 }),
+    );
+
+    const allEvents: GeofenceEvent[] = [];
+    for (const point of walkingCoordinates) {
+      const events = await geofence.evaluate(userId, point.lon, point.lat, point.tst);
+      allEvents.push(...events);
+    }
+
+    expect(allEvents).toHaveLength(2);
+    expect(allEvents[0]).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+    expect(allEvents[1]).toMatchObject({ _type: 'area.exited', areaId: 'a1' });
+  });
+
+  test('11. no areas: locations for a user with zero areas produce no events', async () => {
+    const userId = nextUserId();
+    const events = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(events).toEqual([]);
+  });
+
+  test('12. add/remove lifecycle: removing an area stops further events and clears state', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const entered = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(entered).toHaveLength(1);
+
+    await areaRepo.removeArea(userId, 'a1');
+
+    const isInside = await redis.sismember(`geofence:inside:${userId}`, 'a1');
+    expect(isInside).toBe(false);
+
+    const events = await geofence.evaluate(userId, -71.1, 42.4, 1060);
+    expect(events).toEqual([]);
+  });
+
+  test('13. radius change: remove + re-add recomputes membership against the new radius', async () => {
+    const userId = nextUserId();
+    const center = { lat: 42.4, lon: -71.1 };
+    // ~80m north of center
+    const point = { lat: center.lat + (80 / 6372797.560856) * (180 / Math.PI), lon: center.lon };
+
+    await areaRepo.addArea(
+      buildArea({ id: 'a1', userId, lat: center.lat, lon: center.lon, radius: 50 }),
+    );
+    const outsideOfSmallRadius = await geofence.evaluate(userId, point.lon, point.lat, 1000);
+    expect(outsideOfSmallRadius).toEqual([]);
+
+    await areaRepo.removeArea(userId, 'a1');
+    await areaRepo.addArea(
+      buildArea({ id: 'a1', userId, lat: center.lat, lon: center.lon, radius: 150 }),
+    );
+
+    const insideOfLargeRadius = await geofence.evaluate(userId, point.lon, point.lat, 1060);
+    expect(insideOfLargeRadius).toHaveLength(1);
+    expect(insideOfLargeRadius[0]).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+  });
+
+  test('14. event fan-out: every event reaches Pub/Sub, the DB, and notifications; a failing sink does not block the rest', async () => {
+    const userId = nextUserId();
+    await areaRepo.addArea(buildArea({ id: 'a1', userId, lat: 42.4, lon: -71.1, radius: 100 }));
+
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const repo = new SqliteLocationRepository(db);
+    const notificationSender = mockNotificationSender();
+    const logger = mockLogger();
+
+    // A subscribed connection can only ping/subscribe/unsubscribe, so the
+    // subscriber needs its own connection separate from the one used to
+    // evaluate/publish.
+    const subscriber = createRedisClient(REDIS_URL!);
+    const received: string[] = [];
+    await subscriber.subscribe('geofence:events', (message) => {
+      received.push(message);
+    });
+
+    const failingSink: EventPublisher = {
+      publish: () => Promise.reject(new Error('sink down')),
+    };
+
+    const publisher = new CompositeEventPublisher(
+      [
+        new RedisEventPublisher(redis),
+        new DbEventPublisher(repo),
+        new NotificationEventPublisher(notificationSender),
+        failingSink,
+      ],
+      logger,
+    );
+
+    const events = await geofence.evaluate(userId, -71.1, 42.4, 1000);
+    expect(events).toHaveLength(1);
+
+    for (const event of events) {
+      await publisher.publish(event);
+    }
+
+    // Pub/Sub delivery is asynchronous; give it a moment to arrive.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await subscriber.unsubscribe('geofence:events');
+    subscriber.close();
+
+    expect(received).toHaveLength(1);
+    expect(JSON.parse(received[0]!)).toMatchObject({ _type: 'area.entered', areaId: 'a1' });
+
+    const row = db.query('SELECT * FROM area_events').get() as { area_id: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.area_id).toBe('a1');
+
+    expect(notificationSender.sendNotification).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    db.close();
+  });
+});

--- a/src/infrastructure/geofence/redis.geofence.test.ts
+++ b/src/infrastructure/geofence/redis.geofence.test.ts
@@ -1,7 +1,6 @@
 import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'bun:test';
-import type { RedisClient } from 'bun';
+import { RedisClient } from 'bun';
 import { Database } from 'bun:sqlite';
-import { createRedisClient } from '@/infrastructure/redis/client.ts';
 import { RedisAreaRepository } from '@/repository/area-repository/redis.repository.ts';
 import { RedisGeofenceEvaluator } from '@/infrastructure/geofence/redis.geofence-evaluator.ts';
 import { RedisEventPublisher } from '@/infrastructure/events/redis.event-publisher.ts';
@@ -26,7 +25,7 @@ describe.skipIf(!REDIS_URL)('RedisAreaRepository + RedisGeofenceEvaluator', () =
   let userCounter = 0;
 
   beforeAll(() => {
-    redis = createRedisClient(REDIS_URL!);
+    redis = new RedisClient(REDIS_URL!);
     areaRepo = new RedisAreaRepository(redis);
     geofence = new RedisGeofenceEvaluator(redis, THRESHOLD_SECONDS);
   });
@@ -288,7 +287,7 @@ describe.skipIf(!REDIS_URL)('RedisAreaRepository + RedisGeofenceEvaluator', () =
     // A subscribed connection can only ping/subscribe/unsubscribe, so the
     // subscriber needs its own connection separate from the one used to
     // evaluate/publish.
-    const subscriber = createRedisClient(REDIS_URL!);
+    const subscriber = new RedisClient(REDIS_URL!);
     const received: string[] = [];
     await subscriber.subscribe('geofence:events', (message) => {
       received.push(message);

--- a/src/infrastructure/http/server.test.ts
+++ b/src/infrastructure/http/server.test.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from '@/infrastructure/logging/console.logger.ts';
 import { runMigrations } from '@/infrastructure/persistence/migrate.ts';
 import { SqliteLocationRepository } from '@/repository/location-repository/sqlite.repository';
 import { LibsodiumDecryptor } from '@/infrastructure/crypto/libsodium.decryptor';
+import { mockAreaRepository, mockEventPublisher, mockGeofenceEvaluator } from '@/test/mocks.ts';
 import type { Deps } from '@/application/handle-payload.ts';
 import type { Server } from 'node:http';
 import type { Geocoder, PayloadDecryptor } from '@/domain/ports';
@@ -34,6 +35,9 @@ beforeAll(async () => {
     reverseGeocoder: {
       reverseGeocode: async () => mockGeocodeResult,
     } satisfies Geocoder,
+    geofence: mockGeofenceEvaluator(),
+    eventPublisher: mockEventPublisher(),
+    areaRepo: mockAreaRepository(),
   };
 
   const app = createHttpServer(deps);

--- a/src/infrastructure/http/server.ts
+++ b/src/infrastructure/http/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { OwnTracksPayloadSchema } from '@/domain/schemas.ts';
+import { AreaSchema, OwnTracksPayloadSchema } from '@/domain/schemas.ts';
 import { handlePayload, type Deps } from '@/application/handle-payload.ts';
 
 export function createHttpServer(deps: Deps) {
@@ -38,6 +38,28 @@ export function createHttpServer(deps: Deps) {
 
     await handlePayload(result.data, deps);
     res.status(200).json([]);
+  });
+
+  app.post('/areas', async (req, res) => {
+    const result = AreaSchema.safeParse(req.body);
+
+    if (!result.success) {
+      res.status(400).json({ error: 'Invalid area', issues: result.error.issues });
+      return;
+    }
+
+    await deps.areaRepo.addArea(result.data);
+    res.status(200).json(result.data);
+  });
+
+  app.get('/areas/:userId', async (req, res) => {
+    const areas = await deps.areaRepo.listAreas(req.params.userId);
+    res.status(200).json(areas);
+  });
+
+  app.delete('/areas/:userId/:areaId', async (req, res) => {
+    await deps.areaRepo.removeArea(req.params.userId, req.params.areaId);
+    res.status(204).send();
   });
 
   return app;

--- a/src/infrastructure/notifications/log.notification-sender.ts
+++ b/src/infrastructure/notifications/log.notification-sender.ts
@@ -1,0 +1,13 @@
+import type { Logger, NotificationSender } from '@/domain/ports.ts';
+
+export class LogNotificationSender implements NotificationSender {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  async sendNotification(subject: string, body: string): Promise<void> {
+    this.logger.info(`Notification: ${subject}`, { body });
+  }
+}

--- a/src/infrastructure/persistence/schema.ts
+++ b/src/infrastructure/persistence/schema.ts
@@ -59,3 +59,15 @@ export const transitions = sqliteTable('transitions', {
   rid: text('rid'),
   created_at: text('created_at').default(sql`(datetime('now'))`),
 });
+
+export const area_events = sqliteTable('area_events', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  type: text('type').notNull(),
+  user_id: text('user_id').notNull(),
+  area_id: text('area_id').notNull(),
+  area_name: text('area_name'),
+  lat: real('lat').notNull(),
+  lon: real('lon').notNull(),
+  tst: integer('tst').notNull(),
+  created_at: text('created_at').default(sql`(datetime('now'))`),
+});

--- a/src/infrastructure/redis/client.ts
+++ b/src/infrastructure/redis/client.ts
@@ -1,5 +1,3 @@
-import { RedisClient } from 'bun';
-
-export function createRedisClient(url: string): RedisClient {
-  return new RedisClient(url);
+export function createRedisClient(): typeof Bun.redis {
+  return Bun.redis;
 }

--- a/src/infrastructure/redis/client.ts
+++ b/src/infrastructure/redis/client.ts
@@ -1,0 +1,5 @@
+import { RedisClient } from 'bun';
+
+export function createRedisClient(url: string): RedisClient {
+  return new RedisClient(url);
+}

--- a/src/infrastructure/redis/keys.ts
+++ b/src/infrastructure/redis/keys.ts
@@ -1,0 +1,19 @@
+export function geoAreasKey(userId: string): string {
+  return `geo:areas:${userId}`;
+}
+
+export function areaMetaKey(userId: string): string {
+  return `area:meta:${userId}`;
+}
+
+export function areaMaxRadiusKey(userId: string): string {
+  return `area:maxradius:${userId}`;
+}
+
+export function geofenceInsideKey(userId: string): string {
+  return `geofence:inside:${userId}`;
+}
+
+export function geofencePendingExitKey(userId: string): string {
+  return `geofence:pending-exit:${userId}`;
+}

--- a/src/repository/area-repository/redis.repository.ts
+++ b/src/repository/area-repository/redis.repository.ts
@@ -1,0 +1,115 @@
+import type { RedisClient } from 'bun';
+import type { Area } from '@/domain/types.ts';
+import type { AreaRepository } from '@/domain/ports.ts';
+import {
+  areaMaxRadiusKey,
+  areaMetaKey,
+  geoAreasKey,
+  geofenceInsideKey,
+  geofencePendingExitKey,
+} from '@/infrastructure/redis/keys.ts';
+
+type AreaMeta = { name: string; radius: number };
+
+export class RedisAreaRepository implements AreaRepository {
+  private redis: RedisClient;
+
+  constructor(redis: RedisClient) {
+    this.redis = redis;
+  }
+
+  async addArea(area: Area): Promise<void> {
+    await this.redis.send('GEOADD', [
+      geoAreasKey(area.userId),
+      String(area.lon),
+      String(area.lat),
+      area.id,
+    ]);
+    await this.redis.hset(areaMetaKey(area.userId), {
+      [area.id]: JSON.stringify({ name: area.name, radius: area.radius } satisfies AreaMeta),
+    });
+    await this.recomputeMaxRadius(area.userId);
+  }
+
+  async removeArea(userId: string, areaId: string): Promise<void> {
+    await this.redis.zrem(geoAreasKey(userId), areaId);
+    await this.redis.hdel(areaMetaKey(userId), areaId);
+    await this.recomputeMaxRadius(userId);
+    await this.redis.srem(geofenceInsideKey(userId), areaId);
+    await this.redis.hdel(geofencePendingExitKey(userId), areaId);
+  }
+
+  async listAreas(userId: string): Promise<Area[]> {
+    const meta = await this.redis.hgetall(areaMetaKey(userId));
+    const areaIds = Object.keys(meta);
+    if (areaIds.length === 0) {
+      return [];
+    }
+
+    const positions = (await this.redis.send('GEOPOS', [geoAreasKey(userId), ...areaIds])) as (
+      | [string, string]
+      | null
+    )[];
+
+    const areas: Area[] = [];
+    areaIds.forEach((areaId, index) => {
+      const position = positions[index];
+      if (!position) {
+        return;
+      }
+      const { name, radius } = JSON.parse(meta[areaId]!) as AreaMeta;
+      areas.push({
+        id: areaId,
+        userId,
+        name,
+        lon: Number(position[0]),
+        lat: Number(position[1]),
+        radius,
+      });
+    });
+
+    return areas;
+  }
+
+  async getArea(userId: string, areaId: string): Promise<Area | undefined> {
+    const rawMeta = await this.redis.hget(areaMetaKey(userId), areaId);
+    if (rawMeta === null) {
+      return undefined;
+    }
+
+    const positions = (await this.redis.send('GEOPOS', [geoAreasKey(userId), areaId])) as (
+      | [string, string]
+      | null
+    )[];
+    const position = positions[0];
+    if (!position) {
+      return undefined;
+    }
+
+    const { name, radius } = JSON.parse(rawMeta) as AreaMeta;
+    return {
+      id: areaId,
+      userId,
+      name,
+      lon: Number(position[0]),
+      lat: Number(position[1]),
+      radius,
+    };
+  }
+
+  async healthCheck(): Promise<void> {
+    await this.redis.ping();
+  }
+
+  private async recomputeMaxRadius(userId: string): Promise<void> {
+    const meta = await this.redis.hgetall(areaMetaKey(userId));
+    const radii = Object.values(meta).map((json) => (JSON.parse(json) as AreaMeta).radius);
+
+    if (radii.length === 0) {
+      await this.redis.del(areaMaxRadiusKey(userId));
+      return;
+    }
+
+    await this.redis.set(areaMaxRadiusKey(userId), String(Math.max(...radii)));
+  }
+}

--- a/src/repository/location-repository/postgres.repository.ts
+++ b/src/repository/location-repository/postgres.repository.ts
@@ -5,6 +5,7 @@ import type {
   TransitionPayload,
   WaypointPayload,
 } from '@/domain/types.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
 import type { LocationRepository } from '@/domain/ports.ts';
 
 export class PostgresLocationRepository implements LocationRepository {
@@ -147,6 +148,34 @@ export class PostgresLocationRepository implements LocationRepository {
         t TEXT,
         rid TEXT,
         created_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `;
+    await this.conn`
+      CREATE TABLE IF NOT EXISTS area_events (
+        id SERIAL PRIMARY KEY,
+        type TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        area_id TEXT NOT NULL,
+        area_name TEXT,
+        lat DOUBLE PRECISION NOT NULL,
+        lon DOUBLE PRECISION NOT NULL,
+        tst INTEGER NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `;
+  }
+
+  async saveAreaEvent(event: GeofenceEvent): Promise<void> {
+    await this.conn`
+      INSERT INTO area_events (type, user_id, area_id, area_name, lat, lon, tst)
+      VALUES (
+        ${event._type},
+        ${event.userId},
+        ${event.areaId},
+        ${event.areaName ?? null},
+        ${event.lat},
+        ${event.lon},
+        ${event.tst}
       )
     `;
   }

--- a/src/repository/location-repository/sqlite.repository.ts
+++ b/src/repository/location-repository/sqlite.repository.ts
@@ -5,6 +5,7 @@ import type {
   TransitionPayload,
   WaypointPayload,
 } from '@/domain/types.ts';
+import type { GeofenceEvent } from '@/domain/events.ts';
 import type { LocationRepository } from '@/domain/ports.ts';
 
 export class SqliteLocationRepository implements LocationRepository {
@@ -85,6 +86,22 @@ export class SqliteLocationRepository implements LocationRepository {
         address.country ?? null,
         address.countryCode ?? null,
         address.postalCode ?? null,
+      ],
+    );
+  }
+
+  saveAreaEvent(event: GeofenceEvent): void {
+    this.db.run(
+      `INSERT INTO area_events (type, user_id, area_id, area_name, lat, lon, tst)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        event._type,
+        event.userId,
+        event.areaId,
+        event.areaName ?? null,
+        event.lat,
+        event.lon,
+        event.tst,
       ],
     );
   }

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,5 +1,6 @@
 import type {
   Address,
+  Area,
   GeocodingResult,
   LocationPayload,
   TransitionPayload,
@@ -55,6 +56,18 @@ export function buildGeocodingResult(overrides?: Partial<GeocodingResult>): Geoc
     lat: 42.3601,
     lon: -71.0589,
     address: buildAddress(),
+    ...overrides,
+  };
+}
+
+export function buildArea(overrides?: Partial<Area>): Area {
+  return {
+    id: 'area-1',
+    userId: 'AB',
+    name: 'Home',
+    lat: 42.3601,
+    lon: -71.0589,
+    radius: 100,
     ...overrides,
   };
 }

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,5 +1,13 @@
 import { mock } from 'bun:test';
-import type { Geocoder, LocationRepository, Logger, NotificationSender } from '@/domain/ports.ts';
+import type {
+  AreaRepository,
+  EventPublisher,
+  Geocoder,
+  GeofenceEvaluator,
+  LocationRepository,
+  Logger,
+  NotificationSender,
+} from '@/domain/ports.ts';
 import type { GeocodingResult } from '@/domain/types.ts';
 
 export function mockLocationRepository(): {
@@ -10,7 +18,36 @@ export function mockLocationRepository(): {
     saveTransition: mock(() => {}),
     saveWaypoint: mock(() => {}),
     saveAddress: mock(() => {}),
+    saveAreaEvent: mock(() => {}),
     healthCheck: mock(() => Promise.resolve()),
+  };
+}
+
+export function mockAreaRepository(): {
+  [K in keyof AreaRepository]: ReturnType<typeof mock>;
+} {
+  return {
+    addArea: mock(() => {}),
+    removeArea: mock(() => {}),
+    listAreas: mock(() => Promise.resolve([])),
+    getArea: mock(() => Promise.resolve(undefined)),
+    healthCheck: mock(() => Promise.resolve()),
+  };
+}
+
+export function mockGeofenceEvaluator(): {
+  [K in keyof GeofenceEvaluator]: ReturnType<typeof mock>;
+} {
+  return {
+    evaluate: mock(() => Promise.resolve([])),
+  };
+}
+
+export function mockEventPublisher(): {
+  [K in keyof EventPublisher]: ReturnType<typeof mock>;
+} {
+  return {
+    publish: mock(() => Promise.resolve()),
   };
 }
 


### PR DESCRIPTION
## Summary

Implements geofencing for predefined areas using Redis geo-indexing and a Lua-based atomic evaluator. When a location update arrives, the system checks whether the user has entered or exited any registered areas and publishes domain events (via Redis pub/sub, database, and notification channels) to downstream consumers.

Closes #18
Closes #6

## Changes

**Domain**
- `src/domain/events.ts` — `GeofenceEvent`, `area.entered` / `area.exited` domain events
- `src/domain/ports.ts` — `AreaRepository`, `GeofenceEvaluator`, `EventPublisher` interfaces
- `src/domain/types.ts` / `src/domain/schemas.ts` — `Area` type and Zod schema

**Infrastructure**
- `src/infrastructure/geofence/redis.geofence-evaluator.ts` — atomic Lua-based geofence evaluator using Redis GEO + sets
- `src/infrastructure/geofence/geofence.lua.ts` — Lua script for enter/exit detection with hysteresis (configurable exit threshold)
- `src/infrastructure/events/redis.event-publisher.ts` — publishes events to `geofence:events` Redis channel
- `src/infrastructure/events/db.event-publisher.ts` — persists events to `area_events` table
- `src/infrastructure/events/notification.event-publisher.ts` — sends notifications via `NotificationSender`
- `src/infrastructure/events/composite.event-publisher.ts` — fan-out publisher with per-sink error isolation
- `src/infrastructure/notifications/log.notification-sender.ts` — logs notifications (initial implementation)
- `src/infrastructure/redis/client.ts` — `createRedisClient()` using `Bun.redis`
- `src/infrastructure/redis/keys.ts` — centralised Redis key helpers

**Repository**
- `src/repository/area-repository/redis.repository.ts` — CRUD for areas backed by Redis GEO + hashes
- `src/repository/location-repository/sqlite.repository.ts` / `postgres.repository.ts` — `saveAreaEvent` added

**HTTP API**
- `POST /areas` — register a geofenced area
- `GET /areas/:userId` — list areas for a user
- `DELETE /areas/:userId/:areaId` — remove an area

**Application**
- `src/application/handlers/location.handler.ts` — triggers geofence evaluation and event publishing on every location update
- `src/application/handle-payload.ts` — `Deps` extended with `geofence`, `eventPublisher`, `areaRepo`

**Database**
- `drizzle/0003_kind_hedge_knight.sql` — `area_events` table migration

**Docs**
- `docs/geofencing.md` — full spec covering state machine, Lua script, event schema, and API

## Testing

```bash
# Unit + integration tests (Redis tests skipped without REDIS_URL)
bun test

# With a local Redis instance
REDIS_URL=redis://localhost:6379 bun test src/infrastructure/geofence/redis.geofence.test.ts

# Register an area
curl -X POST http://localhost:3001/areas \
  -H 'Content-Type: application/json' \
  -d '{"id":"home","userId":"alice","name":"Home","lat":42.36,"lon":-71.06,"radius":100}'

# List areas
curl http://localhost:3001/areas/alice

# Send a location inside the area — triggers area.entered event
curl -X POST http://localhost:3001/pub \
  -H 'Content-Type: application/json' \
  -d '{"_type":"location","lat":42.36,"lon":-71.06,"tst":1700000000,"tid":"AA"}'
```

## Checklist

- [x] Tests pass (69 pass, 16 Redis integration tests skipped without local Redis)
- [x] `just typecheck` passes
- [x] `just lint-ts` passes
- [x] Geofencing spec documented in `docs/geofencing.md`
- [x] Database migration included